### PR TITLE
add missing include

### DIFF
--- a/gui/qt/qcustomplot.h
+++ b/gui/qt/qcustomplot.h
@@ -54,6 +54,7 @@
 #include <QtCore/QSharedPointer>
 #include <QtCore/QTimer>
 #include <QtGui/QPainter>
+#include <QtGui/QPainterPath>
 #include <QtGui/QPaintEvent>
 #include <QtGui/QMouseEvent>
 #include <QtGui/QWheelEvent>


### PR DESCRIPTION
Hello,

Trying to compile this on ArchLinux raised this error:

```
[ 63%] Building CXX object gui/CMakeFiles/gui.dir/gui_autogen/mocs_compilation.cpp.o
In file included from …/pololu-jrk-g2-software/build/gui/gui_autogen/WTNNEUUVOU/../../../../gui/qt/main_window.h:3,
                 from …/pololu-jrk-g2-software/build/gui/gui_autogen/WTNNEUUVOU/../../../../gui/qt/feedback_wizard.h:6,
                 from …/pololu-jrk-g2-software/build/gui/gui_autogen/WTNNEUUVOU/moc_feedback_wizard.cpp:10,
                 from …/pololu-jrk-g2-software/build/gui/gui_autogen/mocs_compilation.cpp:4:
…/pololu-jrk-g2-software/build/gui/gui_autogen/WTNNEUUVOU/../../../../gui/qt/qcustomplot.h:2378:16: error: field 'mCustomPath' has incomplete type 'QPainterPath'
 2378 |   QPainterPath mCustomPath;
      |                ^~~~~~~~~~~
```

This commit fixed this for me.